### PR TITLE
Use Log.getStackTraceString in JULHandle example

### DIFF
--- a/example/src/de/duenndns/mtmexample/JULHandler.java
+++ b/example/src/de/duenndns/mtmexample/JULHandler.java
@@ -2,9 +2,7 @@ package de.duenndns.mtmexample;
 
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.PrintWriter;
 import java.io.StringBufferInputStream;
-import java.io.StringWriter;
 import java.util.logging.Formatter;
 import java.util.logging.Handler;
 import java.util.logging.Level;
@@ -81,12 +79,8 @@ public class JULHandler extends Handler {
 		public String format(LogRecord logRecord) {
 			Throwable thrown = logRecord.getThrown();
 			if (thrown != null) {
-				StringWriter sw = new StringWriter();
-				PrintWriter pw = new PrintWriter(sw, false);
-				pw.write(logRecord.getMessage() + ' ');
-				thrown.printStackTrace(pw);
-				pw.flush();
-				return sw.toString();
+				String stacktrace = Log.getStackTraceString(thrown);
+				return logRecord.getMessage() + ' ' + stacktrace;
 			} else {
 				return logRecord.getMessage();
 			}


### PR DESCRIPTION
the previously used implementation to print the stacktrace would only
print the stacktrace of the resulting Exception/Throwable, but the
really relevant stacktrace is the one from the causing
Exception/Throwable. Androids android.util.Log.getStackTraceString()
achieves this by

```java
while (t != null) {
    t = t.getCause();
}
```
