### PR TITLE
Log reason when file key store is not accessible

### DIFF
--- a/src/de/duenndns/ssl/MemorizingTrustManager.java
+++ b/src/de/duenndns/ssl/MemorizingTrustManager.java
@@ -327,13 +327,13 @@ public class MemorizingTrustManager implements X509TrustManager {
 			is = new java.io.FileInputStream(keyStoreFile);
 			ks.load(is, "MTM".toCharArray());
 		} catch (NoSuchAlgorithmException | CertificateException | IOException e) {
-			LOGGER.log(Level.INFO, "getAppKeyStore(" + keyStoreFile + ") - exception loading file key store");
+			LOGGER.log(Level.INFO, "getAppKeyStore(" + keyStoreFile + ") - exception loading file key store", e);
 		} finally {
 			if (is != null) {
 				try {
 					is.close();
 				} catch (IOException e) {
-					LOGGER.log(Level.FINE, "getAppKeyStore(" + keyStoreFile + ") - exception closing file key store input stream");
+					LOGGER.log(Level.FINE, "getAppKeyStore(" + keyStoreFile + ") - exception closing file key store input stream", e);
 				}
 			}
 		}


### PR DESCRIPTION
I have the problem that I often get exceptions when loading the key store, but I can't tell the reason from the logs.

This pull requests adds the reason to the logs.