### PR TITLE
Remove deprecated methods, use Notification.Builder

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,11 +10,11 @@ buildscript {
 apply plugin: 'com.android.library'
 
 android {
-	compileSdkVersion 21
+	compileSdkVersion 23
 	buildToolsVersion "21.1.1"
 	defaultConfig {
 		minSdkVersion 7
-		targetSdkVersion 21
+		targetSdkVersion 23
 	}
 
 	sourceSets {

--- a/example/build.gradle
+++ b/example/build.gradle
@@ -5,11 +5,11 @@ dependencies {
 }
 
 android {
-	compileSdkVersion 21
+	compileSdkVersion 23
 	buildToolsVersion "21.1.1"
 	defaultConfig {
 		minSdkVersion 7
-		targetSdkVersion 21
+		targetSdkVersion 23
 	}
 
 	sourceSets {

--- a/example/project.properties
+++ b/example/project.properties
@@ -9,4 +9,4 @@
 
 android.library.reference.1=../
 # Project target.
-target=android-21
+target=android-23

--- a/project.properties
+++ b/project.properties
@@ -9,4 +9,4 @@
 
 android.library=true
 # Project target.
-target=android-21
+target=android-23

--- a/src/de/duenndns/ssl/MemorizingTrustManager.java
+++ b/src/de/duenndns/ssl/MemorizingTrustManager.java
@@ -42,6 +42,8 @@ import android.os.Handler;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
 import java.security.cert.*;
 import java.security.KeyStore;
 import java.security.KeyStoreException;
@@ -567,25 +569,70 @@ public class MemorizingTrustManager implements X509TrustManager {
 		return si.toString();
 	}
 
-	void startActivityNotification(Intent intent, int decisionId, String certName) {
-		if (Build.VERSION.SDK_INT < Build.VERSION_CODES.HONEYCOMB) {
-			LOGGER.warning("Can't fallback showing a notification. Android API level to low, requires at least 11 but was "
-					+ Build.VERSION.SDK_INT);
-			return;
+	/**
+	 * Reflectively call
+	 * <code>Notification.setLatestEventInfo(Context, CharSequence, CharSequence, PendingIntent)</code>
+	 * since it was remove in Android API level 23.
+	 *
+	 * @param notification
+	 * @param context
+	 * @param mtmNotification
+	 * @param certName
+	 * @param call
+	 */
+	private static void setLatestEventInfoReflective(Notification notification,
+			Context context, CharSequence mtmNotification,
+			CharSequence certName, PendingIntent call) {
+		Method setLatestEventInfo;
+		try {
+			setLatestEventInfo = notification.getClass().getMethod(
+					"setLatestEventInfo", Context.class, CharSequence.class,
+					CharSequence.class, PendingIntent.class);
+		} catch (NoSuchMethodException e) {
+			throw new IllegalStateException(e);
 		}
 
-		PendingIntent call = PendingIntent.getActivity(master, 0, intent, 0);
-		final Notification n = new Notification.Builder(master)
-					.setContentTitle(master.getString(R.string.mtm_notification))
+		try {
+			setLatestEventInfo.invoke(notification, context, mtmNotification,
+					certName, call);
+		} catch (IllegalAccessException | IllegalArgumentException
+				| InvocationTargetException e) {
+			throw new IllegalStateException(e);
+		}
+	}
+
+	void startActivityNotification(Intent intent, int decisionId, String certName) {
+		Notification notification;
+		final PendingIntent call = PendingIntent.getActivity(master, 0, intent,
+				0);
+		final String mtmNotification = master.getString(R.string.mtm_notification);
+		final long currentMillis = System.currentTimeMillis();
+		final Context context = master.getApplicationContext();
+
+		if (Build.VERSION.SDK_INT < Build.VERSION_CODES.HONEYCOMB) {
+			@SuppressWarnings("deprecation")
+			// Use an extra identifier for the legacy build notification, so
+			// that we suppress the deprecation warning. We will latter assign
+			// this to the correct identifier.
+			Notification n  = new Notification(android.R.drawable.ic_lock_lock,
+					mtmNotification,
+					currentMillis);
+			setLatestEventInfoReflective(n, context, mtmNotification, certName, call);
+			n.flags |= Notification.FLAG_AUTO_CANCEL;
+			notification = n;
+		} else {
+			notification = new Notification.Builder(master)
+					.setContentTitle(mtmNotification)
 					.setContentText(certName)
 					.setTicker(certName)
 					.setSmallIcon(android.R.drawable.ic_lock_lock)
-					.setWhen(System.currentTimeMillis())
+					.setWhen(currentMillis)
 					.setContentIntent(call)
 					.setAutoCancel(true)
 					.build();
+		}
 
-		notificationManager.notify(NOTIFICATION_ID + decisionId, n);
+		notificationManager.notify(NOTIFICATION_ID + decisionId, notification);
 	}
 
 	/**

--- a/src/de/duenndns/ssl/MemorizingTrustManager.java
+++ b/src/de/duenndns/ssl/MemorizingTrustManager.java
@@ -36,6 +36,7 @@ import android.content.Context;
 import android.content.Intent;
 import android.net.Uri;
 import android.util.SparseArray;
+import android.os.Build;
 import android.os.Handler;
 
 import java.io.File;
@@ -566,17 +567,23 @@ public class MemorizingTrustManager implements X509TrustManager {
 		return si.toString();
 	}
 
-	// We can use Notification.Builder once MTM's minSDK is >= 11
-	@SuppressWarnings("deprecation")
 	void startActivityNotification(Intent intent, int decisionId, String certName) {
-		Notification n = new Notification(android.R.drawable.ic_lock_lock,
-				master.getString(R.string.mtm_notification),
-				System.currentTimeMillis());
+		if (Build.VERSION.SDK_INT < Build.VERSION_CODES.HONEYCOMB) {
+			LOGGER.warning("Can't fallback showing a notification. Android API level to low, requires at least 11 but was "
+					+ Build.VERSION.SDK_INT);
+			return;
+		}
+
 		PendingIntent call = PendingIntent.getActivity(master, 0, intent, 0);
-		n.setLatestEventInfo(master.getApplicationContext(),
-				master.getString(R.string.mtm_notification),
-				certName, call);
-		n.flags |= Notification.FLAG_AUTO_CANCEL;
+		final Notification n = new Notification.Builder(master)
+					.setContentTitle(master.getString(R.string.mtm_notification))
+					.setContentText(certName)
+					.setTicker(certName)
+					.setSmallIcon(android.R.drawable.ic_lock_lock)
+					.setWhen(System.currentTimeMillis())
+					.setContentIntent(call)
+					.setAutoCancel(true)
+					.build();
 
 		notificationManager.notify(NOTIFICATION_ID + decisionId, n);
 	}


### PR DESCRIPTION
makes MTM Android API 23 compatible, since

Notification.setLatestEventInfo(Context, CharSequence, CharSequence,
PendingIntent)

was removed with this API level.