### PR TITLE
Bump Android Gradle plugin to 3.6.3

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,9 +2,10 @@ buildscript {
 	repositories {
 		mavenCentral()
 		google()
+		jcenter()
 	}
 	dependencies {
-		classpath 'com.android.tools.build:gradle:3.1.3'
+		classpath 'com.android.tools.build:gradle:3.6.3'
 	}
 }
 


### PR DESCRIPTION
This also requires that we add jcenter() to the list of repositories,
as otherwise we run into

A problem occurred configuring project ':memorizingTrustManager'.
> Could not resolve all artifacts for configuration ':memorizingTrustManager:classpath'.
   > Could not find org.jetbrains.trove4j:trove4j:20160824.
     Searched in the following locations:
       - https://repo.maven.apache.org/maven2/org/jetbrains/trove4j/trove4j/20160824/trove4j-20160824.pom
       - https://dl.google.com/dl/android/maven2/org/jetbrains/trove4j/trove4j/20160824/trove4j-20160824.pom
     Required by:
         project :memorizingTrustManager > com.android.tools.build:gradle:3.6.3 > com.android.tools.build:builder:3.6.3 > com.android.tools:sdk-common:26.6.3