### PR TITLE
Gradle build: do not abort on lint errors

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -21,6 +21,9 @@ android {
 		minSdkVersion 9
 		targetSdkVersion 29
 	}
+	lintOptions {
+		abortOnError false
+	}
 
 	sourceSets {
 		main {


### PR DESCRIPTION
This will continue to show lint warnings but will not abort the build
Fixes #68 
